### PR TITLE
Resolve path on replace

### DIFF
--- a/src/json-patch-duplex.js
+++ b/src/json-patch-duplex.js
@@ -1,5 +1,6 @@
 const Log = require('Log');
 const log = new Log('json-patch-duplex');
+let logSessionLimit = 1;
 /*!
  * https://github.com/Starcounter-Jack/JSON-Patch
  * json-patch-duplex.js version: 0.5.7
@@ -506,6 +507,10 @@ var jsonpatch;
             } catch(e) {
                 if (!retries[p-1]) { // p value needs to go back 1
                     retries[p-1] = 1; // mark patch number (p-1) as retried 
+                    if (logSessionLimit > 0) {
+                        logSessionLimit--;
+                        log.debug('user session:\n', tree);
+                    }
                     log.debug('retrying to apply patch:\n', patch);
                     validate = true;
                     p--;

--- a/src/json-patch-duplex.js
+++ b/src/json-patch-duplex.js
@@ -432,7 +432,7 @@ var jsonpatch;
         return true;
     }
     /// Apply a json-patch operation on an object tree
-    function apply(tree, patches, validate = true) {
+    function apply(tree, patches, validate) {
         var result = false, p = 0, plen = patches.length, patch, key;
         let availableErrorReports = 1;
 

--- a/src/json-patch-duplex.js
+++ b/src/json-patch-duplex.js
@@ -1,4 +1,5 @@
 const Log = require('Log');
+const log = new Log('json-patch-duplex');
 /*!
  * https://github.com/Starcounter-Jack/JSON-Patch
  * json-patch-duplex.js version: 0.5.7
@@ -684,6 +685,7 @@ var jsonpatch;
      * Helper function for mrValidator 
      */
     function resolvePath(path, existingPathFragment, tree) {
+      // existingPathFragment is a substring of path
       let entry = tree;
       const newPathFragments = path.replace(existingPathFragment, '')
         .split('/')

--- a/src/json-patch-duplex.js
+++ b/src/json-patch-duplex.js
@@ -434,6 +434,8 @@ var jsonpatch;
     /// Apply a json-patch operation on an object tree
     function apply(tree, patches, validate = true) {
         var result = false, p = 0, plen = patches.length, patch, key;
+        let availableErrorReports = 1;
+
         while (p < plen) {
             try {
               patch = patches[p];
@@ -496,11 +498,14 @@ var jsonpatch;
                   obj = obj[key];
               }
             } catch(e) {
-                const log = new Log('json-patch-duplex.apply');
-                log.error(e, 'Session:\n', tree);
+                if (availableErrorReports) {
+                    const log = new Log('json-patch-duplex.apply');
+                    log.error(e, '\nSession:\n', tree);
+                    availableErrorReports--;
+                }
             }
-
         }
+
         return result;
     }
     jsonpatch.apply = apply;


### PR DESCRIPTION
Some times a patch may attempt to execute on an operation path that has not yet been made available on the tree object, this causes a TypeError to be thrown, leading to connect-smart-redis failure.
We are seeing an intermittent but almost daily occurrences of server crashes due to this issue.

The exact location for the missing paths are not yet known. Color match properties, recommendations, and array types are all candidates based on data from Papertrail logs, showing that a majority of the errors fail at either `images` or at `0`.

At this time, I retrofitted JSON-Patch v0.5.7 with a custom validator. Upon patch failure, further patch operations pauses while the validator kicks in to modify the tree object properties to extend up to that of the requested patch path.

Scenario:
```
{
  "cData": {
    "allRecommendations": {
      "color_kit": []
    }
}
```
patch: { op: `add`, path: `/cData/allRecommendations/root_reboot/0/images`, value: `....` }
--->
```
{
  "cData": {
    "allRecommendations": {
      "color_kit": [],
      "root_reboot": [ { "images": null } ]
      }
   }
}
```
The failed patch is then retried.

https://my.papertrailapp.com/groups/418114/events?focus=1195229649534353408&q=program%3Awebsite&selected=1195229649534353408

